### PR TITLE
Better support for official images from Docker

### DIFF
--- a/src/lambda/get-image-tags-handler.ts
+++ b/src/lambda/get-image-tags-handler.ts
@@ -103,6 +103,11 @@ async function getEcrImageTags(image: string): Promise<ImageIdentifierList> {
 export async function getDockerImageTags(image: string): Promise<string[]> {
 
   const pageSize = 100;
+
+  if (!image.includes('/')) {
+    image = 'library/' + image;
+  }
+
   let url = new URL(`https://hub.docker.com/v2/repositories/${image}/tags?page_size=${pageSize}`);
 
   let results: tagResult[] = [];

--- a/test/index.get-image-tags-handler.test.ts
+++ b/test/index.get-image-tags-handler.test.ts
@@ -11,3 +11,15 @@ test('Docker image tags are loaded through pagination', async (done) => {
   done();
 
 }, 30000);
+
+test('Docker library image tags are loaded through pagination', async (done) => {
+
+  // WHEN
+  let tags = await handler.getDockerImageTags('amazonlinux');
+
+  // THEN
+  expect(tags.length).toBeGreaterThan(0);
+
+  done();
+
+}, 30000);


### PR DESCRIPTION
You can still use the simple name (e.g. `amazonlinux`) and this construct will take care that the Docker API is called correctly. 

Fixes #321