### PR TITLE
fix: Ignore tags where no matching manifest exists for linux/amd64

### DIFF
--- a/src/lambda/docker-adapter.ts
+++ b/src/lambda/docker-adapter.ts
@@ -29,7 +29,10 @@ export async function getDockerImageTags(image: string): Promise<ContainerImage[
     }
   } while (response !== undefined && response.next !== null);
 
-  return results.map(result => {
+  // Return tags when there's at least one amd64/linux image
+  let amdLinuxresults = results.filter(result => result.images.filter(i => i.architecture === 'amd64' && i.os === 'linux').length > 0);
+
+  return amdLinuxresults.map(result => {
     return {
       tag: result.name,
       digest: getDigestForAmd64Linux(result),
@@ -59,7 +62,7 @@ function performRequest(options: RequestOptions) {
   return new Promise((resolve, reject) => {
     request(
       options,
-      function(response) {
+      function (response) {
         const { statusCode } = response;
         if (statusCode === undefined || statusCode >= 300) {
           reject(

--- a/test/docker-adapter.test.ts
+++ b/test/docker-adapter.test.ts
@@ -28,3 +28,16 @@ test('Docker library image tags are loaded through pagination', async (done) => 
 
 }, 30000);
 
+
+test('Docker library image tags include only amd64/linux images', async (done) => {
+
+  // WHEN
+  let tags = await docker.getDockerImageTags('mongo');
+
+  // THEN
+  expect(tags.filter(t => t.tag === '4.2.4').length).toBe(0); // mongo:4.2.4 has only amd64/windows images
+
+  done();
+
+}, 30000);
+


### PR DESCRIPTION
Fixes #369 