### PR TITLE
docs: move repoPrefix from images to EcrSyncProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ In your CDK application, run `npm install @pgarbe/cdk-ecr-sync` and add the foll
 
 ```typescript
 const ecrSync = new EcrSync(this, 'ecrSync', {
+  repoPrefix: 'dockerhub-mirror', // optional prefix
   dockerImages: [
     {
-      repoPrefix: 'dockerhub-mirror', // optional prefix
       imageName: 'datadog/agent',
       excludeTags: [  // Use RegEx expressions to exclude specific tags
         'latest',


### PR DESCRIPTION
When I was copying the example in the README, I noticed that repoPrefix should be one level up in the current version.