### PR TITLE
feat: support multiple lifecycle rules and rules per repository

### DIFF
--- a/src/ecr-sync.ts
+++ b/src/ecr-sync.ts
@@ -28,9 +28,28 @@ export interface EcrSyncProps {
   /**
    * An ECR lifecycle rule which is applied to all repositories.
    *
+   * If both lifcecyleRule and lifcecyleRules are defined,
+   * lifecycleRules wins.
+   *
+   * If lifecycle rules are defied at the repository
+   * level, they win.
+   *
    * @default No lifecycle rules.
    */
   readonly lifcecyleRule?: ecr.LifecycleRule;
+
+  /**
+   * ECR lifecycle rules which are applied to all repositories.
+   *
+   * If both lifcecyleRule and lifcecyleRules are defined,
+   * lifecycleRules wins.
+   *
+   * If lifecycle rules are defied at the repository
+   * level, they win.
+   *
+   * @default No lifecycle rules.
+   */
+  readonly lifecycleRules?: ecr.LifecycleRule[];
 
   /**
    * A prefix for all ECR repository names.
@@ -108,7 +127,11 @@ export class EcrSync extends cdk.Construct {
         resources: [repo.repositoryArn],
       }));
 
-      if (props.lifcecyleRule !== undefined) {
+      if (element.lifecycleRules !== undefined) {
+        element.lifecycleRules.forEach(rule => repo.addLifecycleRule(rule));
+      } else if (props.lifecycleRules !== undefined) {
+        props.lifecycleRules.forEach(rule => repo.addLifecycleRule(rule));
+      } else if (props.lifcecyleRule !== undefined) {
         repo.addLifecycleRule(props.lifcecyleRule);
       }
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,3 +1,5 @@
+import * as ecr from '@aws-cdk/aws-ecr';
+
 /**
  * Properties of a EcrSync image.
  */
@@ -28,4 +30,13 @@ export interface Image {
    * @default Empty. No tags are excluded
    */
   readonly excludeTags?: string[];
+
+  /**
+   * A list of lifecycle rules to apply to this
+   * repository.
+   *
+   * If lifecycle rules are defined at the EcrSync
+   * level, this wins.
+   */
+  readonly lifecycleRules?: ecr.LifecycleRule[];
 }


### PR DESCRIPTION
1. I have left the existing `lifcecyleRule` property of `EcrSyncProps` in place to preserve backward compatibility, and added a `lifecycleRules` property to EcrSyncProps to support multiple rules.

2. I have added a `lifecycleRules` property to `Image` to allow specifying per-repository rules.

This might be overcomplicating the configuration.  Another possibility is to only support multiple rules on a per-repository basis, since if you're being that granular the rules are less likely to apply to all the repositories.

Please let me know what you think.